### PR TITLE
Changes to cover all the DM space and avoid too many candicates.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use NVIDIA Docker image
-FROM nvidia/opencl
+FROM nvidia/opencl:devel-ubuntu18.04
 
 # Install all necessary system packages
 WORKDIR /
@@ -8,9 +8,8 @@ RUN apt-get -qq -y update && apt-get -qq -y install \
     git \
     cmake \
     libgtest-dev \
-    ocl-icd-opencl-dev \
-    opencl-headers
-RUN apt-get clean
+    opencl-headers \
+    && apt-get clean
 
 # Install Google Test
 WORKDIR /usr/src/gtest/build
@@ -26,8 +25,11 @@ WORKDIR /opt/amber/AMBER_setup
 RUN ./amber.sh install development
 ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 
+# Run AMBER for the challenge
 WORKDIR /amber_run
-COPY . .
-RUN chmod a+x challenge.sh
+COPY conf .
+COPY challenge_sprint.sh .
+COPY challenge.sh .
+RUN chmod u+x challenge.sh
 ENTRYPOINT ["/bin/bash", "-c"]
 CMD ["/amber_run/challenge.sh"]

--- a/challenge.sh
+++ b/challenge.sh
@@ -5,10 +5,10 @@ nbatch=83
 
 source challenge_sprint.sh
 conf_dir="/amber_run/conf"
-snrmin=5
+snrmin=8
 output="/tmp/run"
 
-amber -debug -opencl_platform ${OPENCL_PLATFORM} -opencl_device ${OPENCL_DEVICE} -device_name ${DEVICE_NAME} -sync -print -snr_standard -padding_file $conf_dir/padding.conf -zapped_channels $conf_dir/zapped_channels.conf -integration_steps $conf_dir/integration_steps.conf -integration_file $conf_dir/integration.conf -subband_dedispersion -dedispersion_stepone_file $conf_dir/dedispersion_stepone.conf -dedispersion_steptwo_file $conf_dir/dedispersion_steptwo.conf -snr_file $conf_dir/snr.conf -output $output -subbands ${SUBBANDS} -dms ${DMS} -dm_first ${DM_FIRST} -dm_step ${DM_STEP} -subbanding_dms ${SUBBANDING_DMS} -subbanding_dm_first ${SUBBANDING_DM_FIRST} -subbanding_dm_step ${SUBBANDING_DM_STEP} -threshold $snrmin -sigproc -stream -data $file -batches $nbatch -channel_bandwidth ${CHANNEL_BANDWIDTH} -min_freq ${MIN_FREQ} -channels ${CHANNELS} -samples ${SAMPLES} -sampling_time ${SAMPLING_TIME} -compact_results
+amber -debug -opencl_platform ${OPENCL_PLATFORM} -opencl_device ${OPENCL_DEVICE} -device_name ${DEVICE_NAME} -sync -print -snr_sc -padding_file $conf_dir/padding.conf -zapped_channels $conf_dir/zapped_channels.conf -integration_steps $conf_dir/integration_steps.conf -integration_file $conf_dir/integration.conf -subband_dedispersion -dedispersion_stepone_file $conf_dir/dedispersion_stepone.conf -dedispersion_steptwo_file $conf_dir/dedispersion_steptwo.conf -snr_file $conf_dir/snr.conf -output $output -subbands ${SUBBANDS} -dms ${DMS} -dm_first ${DM_FIRST} -dm_step ${DM_STEP} -subbanding_dms ${SUBBANDING_DMS} -subbanding_dm_first ${SUBBANDING_DM_FIRST} -subbanding_dm_step ${SUBBANDING_DM_STEP} -threshold $snrmin -sigproc -stream -data $file -batches $nbatch -channel_bandwidth ${CHANNEL_BANDWIDTH} -min_freq ${MIN_FREQ} -channels ${CHANNELS} -samples ${SAMPLES} -sampling_time ${SAMPLING_TIME} -n_sigma ${SNR_SIGMA} -correction_factor ${CORRECTION_FACTOR} -compact_results
 
 # cut first row
 # select columns: DM, S/N, TIME, WIDTH

--- a/challenge_sprint.sh
+++ b/challenge_sprint.sh
@@ -39,12 +39,11 @@ MAX_ITEMS_DIM1="32"
 # Scenario
 ## Switch to select the subbanding mode; dedispersion specific
 SUBBANDING=true
-## Switch to select the SNR Mode ["SNR", "MOMAD", "MOMSIGMACUT"]
-SNR="SNR"
+## Switch to select the SNR Mode ["SNR", "SNR_SC", "MOMAD", "MOMSIGMACUT"]
+SNR="SNR_SC"
 ## Number of channels
 CHANNELS="1536"
 ## Frequency of the lowest channel, in MHz
-#MIN_FREQ="1249.7009277"
 MIN_FREQ="1249.89624023438"
 ## Bandwidth of a channel, in MHz
 CHANNEL_BANDWIDTH="0.1953125"
@@ -56,20 +55,18 @@ SAMPLING_TIME="0.00008192"
 DOWNSAMPLING=1
 ## Number of subbands
 SUBBANDS="32"
-
 ## Number of DMs to dedisperse in step one; subbanding mode only
 SUBBANDING_DMS="128"
 ## First DM in step one; subbanding mode only
-#SUBBANDING_DM_FIRST="1300.0"
 SUBBANDING_DM_FIRST="5.0"
 ## DM step in step one; subbanding mode only
-SUBBANDING_DM_STEP="6.4"
+SUBBANDING_DM_STEP="16.0"
 ## Number of DMs to dedisperse in either the single step or subbanding step two
 DMS="32"
 ## First DM in either the single step or subbanding step two
 DM_FIRST="0.0"
 ## DM step in either the single step or subbanding step two
-DM_STEP="0.2"
+DM_STEP="0.5"
 ## Number of input beams
 BEAMS="1"
 ## Number of synthesized output beams
@@ -88,3 +85,7 @@ ZAPPED_CHANNELS=""
 MEDIAN_STEP=5
 ## Sigma cut value for MOMSIGMACUT mode; this value is currently harcoded in AMBER
 NSIGMA=3
+## Sigma cut for the SNR computation in SNR_SC mode
+SNR_SIGMA=3.00
+## Correction factor for the SNR computation in SNR_SC mode
+CORRECTION_FACTOR=1.014


### PR DESCRIPTION
With this configuration it should be possible to cover all DM space between 5 and ~2000, so that the preliminary tests being run at the moment are more useful.
Plus the threshold is set at 8 to avoid the false positives.